### PR TITLE
introduce new enum type and new column for keeping JSON data for enum…

### DIFF
--- a/devcomReborn/src/main/java/swe574/backend/devcomReborn/template/Field.java
+++ b/devcomReborn/src/main/java/swe574/backend/devcomReborn/template/Field.java
@@ -25,4 +25,7 @@ public class Field {
     private Template template;
 
     private FieldDataType dataType;
+
+    @Column(length = 1000)
+    private String parameters;
 }

--- a/devcomReborn/src/main/java/swe574/backend/devcomReborn/template/FieldDataType.java
+++ b/devcomReborn/src/main/java/swe574/backend/devcomReborn/template/FieldDataType.java
@@ -6,5 +6,6 @@ public enum FieldDataType {
     GEOLOCATION,
     DATE,
     TIME,
-    NUMBER
+    NUMBER,
+    ENUM
 }


### PR DESCRIPTION
… type parameters

This implementation assumes that all operations for enum options are done in UI; the BE only keeps the parameters provided by the user during template creation. That is the BE stores the parameters composed by the UI translated from the user input in a template field. 

When the user wants to have custom enum types in the template (eg., user sets a list of dog breeds one by one), the UI must include these options (= dog breeds) as parameters in a JSON, something like an array of options to display to the user. 

When creating a post, the value field for PostContent object must be set to the index of the option in the array in the UI (eg., you have 4 dog breeds defined in the template; when creating a post, user selects breed 3; so 3 should go in the value field of the PostContent).

When displaying posts, the UI should render the correct option from the value field of the PostContent.

Please consider this and suggest how the BE can improve the life of the FE developer )
